### PR TITLE
Bump PubNubSDK 9.3.5 → 10.1.5 (modernization; Xcode 26 coverage notes)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pubnub/swift.git",
       "state" : {
-        "revision" : "d1f82968fa88caff521c6b623fe69b28444761cc",
-        "version" : "8.3.1"
+        "revision" : "ff529423b2480413d8006cd2ced9bc65aa3e583e",
+        "version" : "10.1.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["Talkshoplive"]),
     ],
     dependencies: [
-            .package(url: "https://github.com/pubnub/swift.git", from: "9.3.0"),
+            .package(url: "https://github.com/pubnub/swift.git", from: "10.1.5"),
             // Add other dependencies if needed
     ],
     targets: [

--- a/Tests/TalkshopliveTests/Mocks/PubNubFakes.swift
+++ b/Tests/TalkshopliveTests/Mocks/PubNubFakes.swift
@@ -1,0 +1,121 @@
+//
+//  PubNubFakes.swift
+//
+//  Minimal stand-ins for PubNubSDK 10.x protocol types so we can
+//  test the TSL conversion layer (`MessageBase.init(pubNubMessage:)`,
+//  `MessageAction.init(action:)`, `MessagePage.init(page:)`) without
+//  a live PubNub connection. These are scoped to the conversion
+//  surface only — not a general-purpose PubNub fake.
+//
+
+import Foundation
+@testable import Talkshoplive
+import PubNubSDK
+
+struct FakePubNubMessage: PubNubMessage {
+    var payload: JSONCodable
+    var actions: [PubNubMessageAction]
+    var publisher: String?
+    var channel: String
+    var subscription: String?
+    var published: Timetoken
+    var metadata: JSONCodable?
+    var messageType: PubNubMessageType
+    var customMessageType: String?
+    var error: PubNubError?
+
+    init(
+        payload: JSONCodable,
+        actions: [PubNubMessageAction] = [],
+        publisher: String? = "fake-publisher",
+        channel: String = "fake-channel",
+        subscription: String? = nil,
+        published: Timetoken = 17_000_000_000_000_000,
+        metadata: JSONCodable? = nil,
+        messageType: PubNubMessageType = .message,
+        customMessageType: String? = nil,
+        error: PubNubError? = nil
+    ) {
+        self.payload = payload
+        self.actions = actions
+        self.publisher = publisher
+        self.channel = channel
+        self.subscription = subscription
+        self.published = published
+        self.metadata = metadata
+        self.messageType = messageType
+        self.customMessageType = customMessageType
+        self.error = error
+    }
+
+    init(from other: PubNubMessage) throws {
+        self.init(
+            payload: other.payload,
+            actions: other.actions,
+            publisher: other.publisher,
+            channel: other.channel,
+            subscription: other.subscription,
+            published: other.published,
+            metadata: other.metadata,
+            messageType: other.messageType,
+            customMessageType: other.customMessageType,
+            error: other.error
+        )
+    }
+}
+
+struct FakePubNubMessageAction: PubNubMessageAction {
+    let actionType: String
+    let actionValue: String
+    let actionTimetoken: Timetoken
+    let messageTimetoken: Timetoken
+    let publisher: String
+    let channel: String
+    let subscription: String?
+    let published: Timetoken?
+
+    init(
+        actionType: String = "reaction",
+        actionValue: String = "❤",
+        actionTimetoken: Timetoken = 17_000_000_000_000_001,
+        messageTimetoken: Timetoken = 17_000_000_000_000_000,
+        publisher: String = "fake-publisher",
+        channel: String = "fake-channel",
+        subscription: String? = nil,
+        published: Timetoken? = nil
+    ) {
+        self.actionType = actionType
+        self.actionValue = actionValue
+        self.actionTimetoken = actionTimetoken
+        self.messageTimetoken = messageTimetoken
+        self.publisher = publisher
+        self.channel = channel
+        self.subscription = subscription
+        self.published = published
+    }
+
+    init(from other: PubNubMessageAction) throws {
+        self.actionType = other.actionType
+        self.actionValue = other.actionValue
+        self.actionTimetoken = other.actionTimetoken
+        self.messageTimetoken = other.messageTimetoken
+        self.publisher = other.publisher
+        self.channel = other.channel
+        self.subscription = other.subscription
+        self.published = other.published
+    }
+}
+
+struct FakeJSONCodable: JSONCodable, Codable {
+    let value: AnyJSON
+
+    init(_ dict: [String: Any]) {
+        self.value = AnyJSON(dict)
+    }
+
+    init(_ string: String) {
+        self.value = AnyJSON(string)
+    }
+
+    var codableValue: AnyJSON { value }
+}

--- a/Tests/TalkshopliveTests/PubNub10MigrationTests.swift
+++ b/Tests/TalkshopliveTests/PubNub10MigrationTests.swift
@@ -1,0 +1,361 @@
+//
+//  PubNub10MigrationTests.swift
+//
+//  Targeted unit tests covering the SDK's PubNub-typed conversion
+//  surface — the code that touches PubNub envelope types and would
+//  break first under a PubNub 9 → 10 transitive bump.
+//
+//  Scope: data conversion only. ChatProvider's PubNub init/subscribe
+//  paths are out of scope (they require a live PubNub session and a
+//  full fake harness, which the directive explicitly bounds against).
+//
+
+import XCTest
+@testable import Talkshoplive
+import PubNubSDK
+
+final class PubNub10MigrationTests: XCTestCase {
+
+    // MARK: - MessageAction(action: PubNubMessageAction)
+
+    func test_messageAction_initFromPubNub_copiesAllFields() {
+        let action = FakePubNubMessageAction(
+            actionType: "reaction",
+            actionValue: "👍",
+            actionTimetoken: 17_111_222_333_444_555,
+            messageTimetoken: 17_111_222_333_444_000,
+            publisher: "user-42"
+        )
+
+        let converted = MessageAction(action: action)
+
+        XCTAssertEqual(converted.actionType, "reaction")
+        XCTAssertEqual(converted.actionValue, "👍")
+        XCTAssertEqual(converted.actionTimetoken, 17_111_222_333_444_555)
+        XCTAssertEqual(converted.publisher, "user-42")
+        XCTAssertEqual(converted.messageTimetoken, "17111222333444000")
+    }
+
+    func test_messageAction_initFromPubNub_truncatesTimetokenToInt() {
+        // Timetoken (UInt64) → Int conversion is lossy on 32-bit. On 64-bit
+        // (our supported targets: iOS 13+, macOS 10.15+) Int is 64-bit, so
+        // values up to Int64.max round-trip cleanly. Pinning the contract.
+        let bigTimetoken: Timetoken = 9_223_372_036_854_775_000 // < Int64.max
+        let action = FakePubNubMessageAction(actionTimetoken: bigTimetoken)
+
+        let converted = MessageAction(action: action)
+
+        XCTAssertEqual(converted.actionTimetoken, Int(bigTimetoken))
+    }
+
+    func test_messageAction_defaultInit_isAllNil() {
+        let empty = MessageAction()
+        XCTAssertNil(empty.actionType)
+        XCTAssertNil(empty.actionValue)
+        XCTAssertNil(empty.actionTimetoken)
+        XCTAssertNil(empty.publisher)
+        XCTAssertNil(empty.messageTimetoken)
+    }
+
+    func test_messageAction_codableRoundtrip() throws {
+        let original = MessageAction(action: FakePubNubMessageAction(
+            actionType: "emoji",
+            actionValue: "🚀",
+            actionTimetoken: 17_111_222_333_444_555,
+            messageTimetoken: 17_111_222_333_444_000,
+            publisher: "user-99"
+        ))
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MessageAction.self, from: encoded)
+
+        XCTAssertEqual(decoded.actionType, "emoji")
+        XCTAssertEqual(decoded.actionValue, "🚀")
+        XCTAssertEqual(decoded.publisher, "user-99")
+        // actionTimetoken is intentionally omitted from encode() in
+        // production code (see MessageData.swift:574-581) — verify the
+        // documented asymmetry rather than asserting equality.
+        XCTAssertNil(decoded.actionTimetoken)
+        XCTAssertEqual(decoded.messageTimetoken, "17111222333444000")
+    }
+
+    // MARK: - MessageBase.toMessageActions
+
+    func test_messageBase_toMessageActions_mapsAll() {
+        let actions: [PubNubMessageAction] = [
+            FakePubNubMessageAction(actionType: "a1", actionValue: "v1"),
+            FakePubNubMessageAction(actionType: "a2", actionValue: "v2"),
+            FakePubNubMessageAction(actionType: "a3", actionValue: "v3"),
+        ]
+        let base = MessageBase()
+
+        let converted = base.toMessageActions(actions: actions)
+
+        XCTAssertEqual(converted.count, 3)
+        XCTAssertEqual(converted.map(\.actionType), ["a1", "a2", "a3"])
+        XCTAssertEqual(converted.map(\.actionValue), ["v1", "v2", "v3"])
+    }
+
+    func test_messageBase_toMessageActions_emptyInputProducesEmptyOutput() {
+        let base = MessageBase()
+        XCTAssertTrue(base.toMessageActions(actions: []).isEmpty)
+    }
+
+    // MARK: - MessageBase.init(pubNubMessage:)
+
+    func test_messageBase_initFromPubNub_copiesEnvelopeFields() {
+        let payload = FakeJSONCodable([
+            "id": 7,
+            "text": "hello",
+            "type": "comment",
+            "platform": "sdk",
+        ])
+        let action = FakePubNubMessageAction(actionType: "like", actionValue: "true")
+        let pubnub = FakePubNubMessage(
+            payload: payload,
+            actions: [action],
+            publisher: "alice",
+            channel: "chan-1",
+            subscription: "chan-1.*",
+            published: 17_500_000_000_000_000,
+            metadata: nil,
+            messageType: .message
+        )
+
+        let base = MessageBase(pubNubMessage: pubnub)
+
+        XCTAssertEqual(base.publisher, "alice")
+        XCTAssertEqual(base.channel, "chan-1")
+        XCTAssertEqual(base.subscription, "chan-1.*")
+        XCTAssertEqual(base.published, "17500000000000000")
+        XCTAssertEqual(base.messageType, .message)
+        XCTAssertEqual(base.actions?.count, 1)
+        XCTAssertEqual(base.actions?.first?.actionType, "like")
+        XCTAssertEqual(base.payload?.id, 7)
+        XCTAssertEqual(base.payload?.text, "hello")
+        XCTAssertEqual(base.payload?.platform, "sdk")
+    }
+
+    func test_messageBase_initFromPubNub_messageTypeFallsBackToUnknownOnExoticRaw() {
+        // PubNubMessageType has matching int rawValues for case .signal (1),
+        // .object (2), .messageAction (3), .file (4) — verify our enum maps
+        // them through cleanly.
+        let pubnub = FakePubNubMessage(
+            payload: FakeJSONCodable("ignored"),
+            messageType: .signal
+        )
+
+        let base = MessageBase(pubNubMessage: pubnub)
+        XCTAssertEqual(base.messageType, .signal)
+    }
+
+    func test_messageBase_initFromPubNub_payloadDecodeFailureLeavesPayloadNil() {
+        // Non-JSON-shaped payload should not produce a MessageData. The
+        // production code silently drops in that case (no throw, no log).
+        let pubnub = FakePubNubMessage(payload: FakeJSONCodable("a-bare-string-not-a-message-object"))
+
+        let base = MessageBase(pubNubMessage: pubnub)
+        XCTAssertNil(base.payload)
+    }
+
+    func test_messageBase_defaultInit_isAllNilExceptUnknown() {
+        let base = MessageBase()
+        XCTAssertNil(base.publisher)
+        XCTAssertNil(base.channel)
+        XCTAssertNil(base.subscription)
+        XCTAssertNil(base.published)
+        XCTAssertEqual(base.messageType, .unknown)
+        XCTAssertNil(base.payload)
+        XCTAssertNil(base.actions)
+        XCTAssertNil(base.metaData)
+    }
+
+    // MARK: - MessagePage <-> PubNubBoundedPageBase
+
+    func test_messagePage_initFromPubNub_copiesStartAndLimit() throws {
+        let pubnubPage = try XCTUnwrap(PubNubBoundedPageBase(start: 17_111, end: nil, limit: 50))
+
+        let page = MessagePage(page: pubnubPage)
+
+        XCTAssertEqual(page.start, 17_111)
+        XCTAssertEqual(page.limit, 50)
+    }
+
+    func test_messagePage_initFromPubNub_handlesNilStart() throws {
+        let pubnubPage = try XCTUnwrap(PubNubBoundedPageBase(start: nil, end: nil, limit: 25))
+
+        let page = MessagePage(page: pubnubPage)
+
+        XCTAssertNil(page.start)
+        XCTAssertEqual(page.limit, 25)
+    }
+
+    func test_messagePage_toPubNubBoundedPage_roundtrip() throws {
+        let page = MessagePage(start: 17_222, limit: 100)
+
+        let pubnubPage = page.toPubNubBoundedPageBase()
+
+        XCTAssertEqual(pubnubPage.start, 17_222)
+        XCTAssertEqual(pubnubPage.limit, 100)
+    }
+
+    func test_messagePage_toPubNubBoundedPage_nilStartCoercesToZero() {
+        // Documented behavior: production code coerces a nil `start` to
+        // `0` when handing back a `PubNubBoundedPageBase` (see
+        // MessageData.swift:514). Pin the contract.
+        let page = MessagePage(start: nil, limit: 25)
+        let pubnubPage = page.toPubNubBoundedPageBase()
+        XCTAssertEqual(pubnubPage.start, 0)
+    }
+
+    func test_messagePage_defaults() {
+        let empty = MessagePage()
+        XCTAssertNil(empty.start)
+        XCTAssertEqual(empty.limit, 25)
+    }
+
+    // MARK: - MessageData encoding/decoding
+
+    func test_messageData_codableRoundtrip() throws {
+        let sender = Sender(id: "u1", name: "Alice", profileUrl: "https://example.com/a.png", externalId: "ext-1")
+        let original = MessageData(
+            id: 42,
+            createdAt: "2026-04-30T10:00:00Z",
+            sender: sender,
+            text: "hello",
+            type: .comment,
+            platform: "sdk",
+            payload: "17500000000000000"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MessageData.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, 42)
+        XCTAssertEqual(decoded.text, "hello")
+        XCTAssertEqual(decoded.type, .comment)
+        XCTAssertEqual(decoded.platform, "sdk")
+        XCTAssertEqual(decoded.timeToken, "17500000000000000")
+        XCTAssertEqual(decoded.sender?.id, "u1")
+        XCTAssertEqual(decoded.sender?.name, "Alice")
+        XCTAssertEqual(decoded.sender?.profileUrl, "https://example.com/a.png")
+    }
+
+    func test_messageData_decodes_senderAsString_legacyFormat() throws {
+        // Backend used to send sender as a bare string instead of a Sender
+        // object. The custom `init(from:)` falls back and constructs a
+        // Sender with id+name set to the string. Guard the legacy path.
+        let json = """
+        {
+            "id": 1,
+            "text": "hi",
+            "type": "comment",
+            "sender": "legacy-sender-string"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(MessageData.self, from: json)
+
+        XCTAssertEqual(decoded.sender?.id, "legacy-sender-string")
+        XCTAssertEqual(decoded.sender?.name, "legacy-sender-string")
+    }
+
+    func test_messageType_decodesUnknownStringAsComment() throws {
+        let json = "\"not-a-known-type\"".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MessageType.self, from: json)
+        XCTAssertEqual(decoded, .comment)
+    }
+
+    func test_messageType_caseInsensitive() throws {
+        let json = "\"COMMENT\"".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MessageType.self, from: json)
+        XCTAssertEqual(decoded, .comment)
+    }
+
+    // MARK: - MessagePayloadKey
+
+    func test_messagePayloadKey_decodesMessageDeleted() throws {
+        let json = "\"message_deleted\"".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MessagePayloadKey.self, from: json)
+        XCTAssertTrue(decoded.isEqual(to: .messageDeleted))
+    }
+
+    func test_messagePayloadKey_decodesCustomString() throws {
+        let json = "\"some_custom_value\"".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MessagePayloadKey.self, from: json)
+        XCTAssertTrue(decoded.isEqual(to: .custom("some_custom_value")))
+    }
+
+    func test_messagePayloadKey_encodesMessageDeleted() throws {
+        let encoded = try JSONEncoder().encode(MessagePayloadKey.messageDeleted)
+        let decoded = try JSONDecoder().decode(String.self, from: encoded)
+        XCTAssertEqual(decoded, "message_deleted")
+    }
+
+    func test_messagePayloadKey_encodesCustom() throws {
+        let encoded = try JSONEncoder().encode(MessagePayloadKey.custom("foo"))
+        let decoded = try JSONDecoder().decode(String.self, from: encoded)
+        XCTAssertEqual(decoded, "foo")
+    }
+
+    func test_messagePayloadKey_isEqualMixedCases() {
+        XCTAssertFalse(MessagePayloadKey.messageDeleted.isEqual(to: .custom("message_deleted")))
+        XCTAssertFalse(MessagePayloadKey.custom("a").isEqual(to: .custom("b")))
+    }
+
+    // MARK: - Sender encode/decode
+
+    func test_sender_decodesProfileUrlAsURL() throws {
+        let json = """
+        { "id": "u1", "name": "Alice", "profileUrl": "https://example.com/a.png", "externalId": "ext-1" }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Sender.self, from: json)
+        XCTAssertEqual(decoded.profileUrl, "https://example.com/a.png")
+    }
+
+    func test_sender_decodesMissingProfileUrlAsNil() throws {
+        let json = """
+        { "id": "u2", "name": "Bob" }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Sender.self, from: json)
+        XCTAssertNil(decoded.profileUrl)
+        XCTAssertEqual(decoded.id, "u2")
+        XCTAssertEqual(decoded.name, "Bob")
+    }
+
+    func test_sender_defaultInitIsAllNil() {
+        let empty = Sender()
+        XCTAssertNil(empty.id)
+        XCTAssertNil(empty.name)
+        XCTAssertNil(empty.profileUrl)
+        XCTAssertNil(empty.externalId)
+    }
+
+    // MARK: - OriginalMessageData / OriginalMessageBase
+
+    func test_originalMessageData_decodesSenderAsString_legacyFormat() throws {
+        let json = """
+        {
+            "id": 9,
+            "text": "wave",
+            "type": "comment",
+            "sender": "legacy-handle"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(OriginalMessageData.self, from: json)
+        XCTAssertEqual(decoded.sender?.id, "legacy-handle")
+        XCTAssertEqual(decoded.sender?.name, "legacy-handle")
+    }
+
+    func test_originalMessageBase_codableRoundtrip() throws {
+        let inner = OriginalMessageData(id: 1, text: "x", type: .comment)
+        let outer = OriginalMessageBase(message: inner)
+
+        let encoded = try JSONEncoder().encode(outer)
+        let decoded = try JSONDecoder().decode(OriginalMessageBase.self, from: encoded)
+
+        XCTAssertEqual(decoded.message?.id, 1)
+        XCTAssertEqual(decoded.message?.text, "x")
+        XCTAssertEqual(decoded.message?.type, .comment)
+    }
+}

--- a/Tests/TalkshopliveTests/ServicesTests/ShowTests.swift
+++ b/Tests/TalkshopliveTests/ServicesTests/ShowTests.swift
@@ -32,9 +32,9 @@ final class ShowTests: XCTestCase {
     }
     
     func testFetchShows() {
-        
+
         // Given
-        let showInstance = Show()
+        let showInstance = Show.shared
         let showKey = "8WtAFFgRO1K0"
         
         // Create an expectation for the asynchronous code
@@ -61,7 +61,7 @@ final class ShowTests: XCTestCase {
     
     func testFetchCurrentEvent() {
         // Given
-        let eventInstance = Show()
+        let eventInstance = Show.shared
         let showKey = "8WtAFFgRO1K0"
         
         // Create an expectation for the asynchronous code

--- a/XCODE26_COMPATIBILITY.md
+++ b/XCODE26_COMPATIBILITY.md
@@ -1,0 +1,99 @@
+# Xcode 26 — Compatibility Notes
+
+**Last updated:** 2026-05-01
+
+This document captures what we learned while modernizing the SDK's PubNub dependency for Xcode 26 and addressing a coverage-reporting issue surfaced by a third-party CI consumer.
+
+## TL;DR
+
+- The SDK is **Xcode 26 compatible** with no source changes.
+- PubNubSDK was bumped from `9.3.5` → `10.1.5` in this release as a **maintenance modernization**, not as a bug fix.
+- A third-party consumer reported empty `.xcresult` code-coverage data under Xcode 26 with the SDK linked. **Root cause is upstream Apple bug FB7724987** at the Xcode + SwiftPM layer, not in this SDK or in PubNub. Section "Coverage reporting under Xcode 26" below explains the workaround.
+
+## What we know
+
+| Statement | Status |
+|---|---|
+| The PubNub `9.3.5 → 10.1.5` bump compiles cleanly under Xcode 26.2 | ✅ Verified — `swift build` clean |
+| The bump does not regress the SDK's public surface | ✅ Verified — public API unchanged; legacy `SubscriptionListener` still works alongside the modern `Subscription` API |
+| The bump introduces no new breaking changes for SDK consumers | ✅ Verified — see "Public API impact" below |
+| 29 new isolated unit tests covering the PubNub-typed conversion surface (`MessageBase.init(pubNubMessage:)`, `MessageAction(action:)`, `MessagePage(page:)`) all pass | ✅ Verified — `MessageData.swift` line coverage 0% → 79.31% |
+| The bump fixes the third-party CI consumer's empty-coverage symptom | ❌ **Not** verified. The diff between PubNub `9.3.5` and `10.1.5` `Package.swift` is one test-target `path` field; SPM coverage instrumentation is derived from the manifest, which is causally inert across this bump. |
+| The empty-coverage symptom is a PubNub or TSL SDK bug | ❌ **No** — it's Apple FB7724987, surfaced when a consumer scheme uses "Gather coverage for specific targets" with any SwiftPM-linked dependency in the graph. Predates Xcode 26. |
+
+## What we don't know
+
+- The exact Xcode patch version, iOS Simulator runtime version, scheme coverage-scope setting, and target structure in the third-party CI environment that originated the report. Those details determine whether FB7724987 is the exact match in their case or whether something else is at play.
+
+## Coverage reporting under Xcode 26
+
+### The symptom
+
+Under Xcode 26, `xcodebuild test -enableCodeCoverage YES` produces an `.xcresult` bundle without coverage data when the consuming scheme is set to "Gather coverage for specific targets" and has SwiftPM dependencies in the graph (including this SDK, since it transitively links `PubNubSDK`). Removing `PubNubSDK` from the dependency graph causes coverage to populate again — because removing any SPM dependency removes the scope-conflict trigger.
+
+### The cause (upstream, unresolved)
+
+Apple Feedback **FB7724987**. Discussed on the Swift Forums:
+[Xcode doesn't gather code coverage from packages when set to "some targets"](https://forums.swift.org/t/xcode-doesnt-gather-code-coverage-from-packages-when-set-to-some-targets/37220).
+
+The bug class predates Xcode 26 and is unresolved as of this writing. It's not in PubNubSDK, not in TalkShopLive's iOS SDK, and not specific to Xcode 26 — Xcode 26 just makes it more visible because more SDK consumers are now noticing the empty coverage data.
+
+### What to do in your project
+
+Two consumer-side workarounds, **independent of any SDK update**:
+
+1. **Switch coverage scope to "All targets," post-process.** In your scheme: Edit Scheme → Test → Options → Code Coverage → **Gather coverage for "All targets"**. Then post-process the `.xcresult` if you need to exclude SDK dependencies from your reporting totals:
+   ```bash
+   xcrun xccov view --report --json out.xcresult \
+     | jq '{targets: [.targets[] | select(.name | startswith("PubNub") | not)]}' \
+     > coverage.json
+   ```
+   Bypasses FB7724987 with no code change.
+
+2. **Vendor `PubNubSDK` as a binary `.xcframework`** instead of consuming it via SwiftPM. Heavier (you lose SPM auto-update flow), but eliminates the SPM coverage scope-bug trigger entirely.
+
+Neither is provided by an SDK update; both are project-configuration decisions on the consumer's side.
+
+### What this release does NOT do
+
+This SDK release **does not include** a fix for FB7724987 because no SDK release can. The bug is at the Xcode + SwiftPM layer, not in the dependency.
+
+If your CI is hitting the symptom: apply one of the two workarounds above. If you need help diagnosing whether your case matches FB7724987 or is something else, please open an issue with the following:
+
+- `xcodebuild -version` output
+- `xcrun simctl runtime list` from your CI runner
+- Your `.xcscheme` file (or a screenshot of scheme → Test → Options → Code Coverage)
+- Your full `xcodebuild test` invocation
+- Your `Package.resolved`
+- A sketch of your app's target structure and how the SDK is linked into each target
+
+## Public API impact of the PubNub `9.3.5 → 10.1.5` bump
+
+**None.** The TSL Swift SDK's public surface is unchanged. Three potential PubNub 10.0 breaking changes were considered; none affect this SDK's code:
+
+| PubNub 10.0 breaking change | Used in this SDK's `Sources/`? |
+|---|---|
+| `LogWriter` protocol refactor | No |
+| `hereNow` capped at 1,000 occupants | No call sites |
+| MPNS push notifications removed | No MPNS / push registration |
+
+`Sources/Talkshoplive/Core/Chat/ChatProvider.swift` uses the legacy `SubscriptionListener(queue:)` + `pubnub.add(listener)` pattern. PubNub 10.1.5 retains this API alongside the modern entity-scoped `pubnub.channel("x").subscription()` pattern. Migration to the modern API is tracked separately and not blocking on this release.
+
+## Toolchain requirement
+
+`swift-tools-version: 5.9` and `swiftLanguageVersions: [.v5]` — **unchanged** in this release. Deployment targets (`.iOS(.v13)`, `.macOS(.v10_15)`) — unchanged. No new Xcode minimum introduced by this SDK's manifest.
+
+## Validation evidence summary
+
+| Check | Result |
+|-------|--------|
+| `swift build` (Xcode 26.2 / Swift 6.2.3, manifest at swift-tools 5.9) | ✅ Clean compile |
+| `swift test --filter PubNub10MigrationTests` | ✅ 29 / 29 pass |
+| `xcodebuild test -enableCodeCoverage YES` against the sample app on Xcode 26.2 + iOS Simulator 26.3.1 | ✅ `** TEST SUCCEEDED **`, `.xcresult` coverage **present** for the app target (8.09%, 400 of 4942 lines). Both PubNub `9.3.5` and `10.1.5` produce **byte-for-byte identical** `.xcresult` data — confirming the bump is causally inert for SPM coverage instrumentation. |
+| Pre-existing 7 backend integration tests (`SHOW_NOT_FOUND`, `AUTHENTICATION_EXCEPTION`) | Pre-existing on `development`; unrelated to PubNub; no regression. |
+
+## Reference
+
+- Apple Feedback FB7724987 → [Swift Forums thread](https://forums.swift.org/t/xcode-doesnt-gather-code-coverage-from-packages-when-set-to-some-targets/37220)
+- PubNub Swift SDK releases → https://github.com/pubnub/swift/releases
+- This SDK's PubNub bump → PR #139


### PR DESCRIPTION
## Summary

Bumps the `PubNubSDK` transitive dependency from `9.3.5` to `10.1.5` as a **maintenance modernization** — current stable, thread-safety improvements (10.1.3), CryptoModule message-action fix (10.1.4), and alignment with the actively-patched 10.1.x line. Closes an 8-month gap.

**Production diff is one line in `Package.swift`:**

```diff
-    .package(url: "https://github.com/pubnub/swift.git", from: "9.3.0"),
+    .package(url: "https://github.com/pubnub/swift.git", from: "10.1.5"),
```

This PR targets `development` (same branch `ios-sdk-app` already pins via SPM). No linkage changes anywhere.

## What we know / what we don't know

**Originally framed as:** "Bump PubNub to fix the Xcode 26 `.xcresult` empty-coverage symptom Walmart reported on 2026-04-15." On 2026-05-01 audit, that framing was **wrong**. Updating the record.

**What we know:**
- The PubNub `9.3.5 → 10.1.5` bump compiles cleanly under Xcode 26.2 / Swift 6.2.3.
- It does **not** regress this SDK's public surface (`SubscriptionListener` legacy path is retained alongside the modern entity-scoped `Subscription` API in 10.1.5; legacy is still used by `ChatProvider`).
- Three audit-listed PubNub 10.0 breaking changes (`LogWriter`, `hereNow`, MPNS) don't affect any code in `Sources/Talkshoplive/` (verified by grep).
- 29 isolated unit tests covering the PubNub-typed conversion surface (`MessageBase.init(pubNubMessage:)`, `MessageAction(action:)`, `MessagePage(page:)`, encode/decode round-trips) — **29 / 29 pass**.
- `MessageData.swift` line coverage went from **0.00% → 79.31%**.
- Local `xcodebuild test -enableCodeCoverage YES` against the sample app on Xcode 26.2 + iOS Simulator 26.3.1 produces an `.xcresult` with non-empty coverage data on this branch.

**What we don't know:**
- Whether this bump fixes the Walmart-reported empty-coverage symptom **specifically**. Local control test on `development` (PubNub `9.3.5`, pre-bump) produces **byte-for-byte identical** `.xcresult` coverage data — same `TSL SDK.app: 8.09% (400/4942)`, same xctest 100% / 100%. The bump is causally inert for SPM coverage instrumentation in our env, because the diff between PubNub `9.3.5` and `10.1.5` `Package.swift` is one test-target `path` field. SPM derives coverage scope behavior from the manifest, and the manifest is essentially unchanged.

**Correction on the record:** an earlier session run on 2026-04-30 produced `xccov view --report` output of `Error: "No coverage data in result bundle"`, which we initially read as a reproduction of Walmart's symptom. It wasn't — the runs failed at `xcodebuild test`'s destination matching because the iOS 26.2 simulator runtime wasn't installed, so tests never executed. The "no coverage data" was a no-tests-ran artifact, not the SPM instrumentation failure. After installing iOS 26.3.1 and retargeting to iPhone 17 (the iPhone 16 line doesn't exist on iOS 26.3+ runtime), tests ran and `.xcresult` was populated on **both** branches. Earlier framing implying we'd seen and fixed the bug was wrong. Surfacing here for the artifact-of-record.

## Walmart-target hypothesis (root cause is upstream, not us)

Bhavik Shah's verbatim phrasing — "our dependency on **the Walmart target** through PubNubSDK" — and our investigation findings together point to **Apple Feedback FB7724987** as the root cause:

> **"Xcode doesn't gather code coverage from packages when set to 'some targets'"** — long-standing, unresolved Xcode/SwiftPM bug.
> Reference: https://forums.swift.org/t/xcode-doesnt-gather-code-coverage-from-packages-when-set-to-some-targets/37220

The bug class **predates Xcode 26**. It fires when a scheme's coverage scope is set to "Gather coverage for specific targets" and the dependency graph includes any SwiftPM-linked package — including this SDK, since it transitively links `PubNubSDK`. Walmart's specific observation, "removing PubNubSDK fixes it," matches FB7724987's behavior exactly: removing **any** SwiftPM dependency removes the scope-conflict trigger.

The remediation lives in **the consumer app's project configuration**, not in this SDK and not in PubNub. **The bump in this PR is orthogonal to FB7724987.** Two consumer-side workarounds, both documented in the new `XCODE26_COMPATIBILITY.md` (added in commit `b4ebf02`):

1. Switch the consumer scheme's coverage scope from "specific targets" to "all targets," then post-process the `.xcresult` to filter SDK-prefixed entries.
2. Vendor `PubNubSDK` as a binary `.xcframework` instead of via SPM.

Neither is provided by an SDK update. The customer-facing comm and remediation should be handed off to whoever owns the consumer relationship at TalkShopLive.

The internal artifact-of-record for this investigation lives in `PUBNUB_XCODE26_AUDIT.md` §9 (workspace-level, not in this repo).

## Commits

| Hash | Subject |
|------|---------|
| `4de13b6` | `chore(pubnub): bump dependency from 9.3.0+ to 10.1.5+` |
| `9395025` | `test(show): use Show.shared singleton instead of private init` |
| `e9b8e15` | `test(pubnub): cover the PubNub 10.x conversion surface` |
| `b4ebf02` | `docs(xcode26): add Xcode 26 compatibility + coverage notes` |

`Package.swift` and `Package.resolved` carry the only production-code changes. The two test commits restore a pre-existing test-target compile break on `development` (`Show()` private init) and add 29 new isolated unit tests covering the PubNub-typed conversion surface. The doc commit adds `XCODE26_COMPATIBILITY.md` capturing the FB7724987 root-cause investigation for SDK consumers who hit the same symptom.

## Public API impact — none

The TSL Swift SDK's public surface is unchanged.

| PubNub 10.0 breaking change | Used in `Sources/Talkshoplive/`? |
|---|---|
| `LogWriter` protocol refactor | No |
| `hereNow` capped at 1,000 occupants | No call sites |
| MPNS push notifications removed | No MPNS / push registration |

`Sources/Talkshoplive/Core/Chat/ChatProvider.swift` uses the legacy `SubscriptionListener(queue:)` + `pubnub.add(listener)` pattern. PubNub 10.1.5 retains this API alongside the modern entity-scoped pattern. Migration to the modern API is tracked in #140 — separate, deferred.

## Toolchain requirement — unchanged

`swift-tools-version: 5.9` and `swiftLanguageVersions: [.v5]` unchanged. Deployment targets (`.iOS(.v13)`, `.macOS(.v10_15)`) unchanged. No new Xcode minimum introduced by the manifest. (A `swift-tools-version: 6.0` bump was considered during development but dropped on production-minimality audit — PubNub 10.1.5's own `Package.swift` is `swift-tools-version:5.9`, so our manifest version isn't the lever.)

## Validation summary

| Check | Result |
|-------|--------|
| `swift build` (Xcode 26.2 / Swift 6.2.3) | ✅ Clean compile |
| Production sources unchanged from `development` compile against PubNub 10.1.5 | ✅ Confirmed |
| 29 new `PubNub10MigrationTests` | ✅ 29 / 29 pass |
| `MessageData.swift` line coverage | **0.00% → 79.31%** |
| `swift test` (full suite) | 37 / 44 pass; the 7 failures are pre-existing integration tests that hit a live TSL backend (`SHOW_NOT_FOUND`, `AUTHENTICATION_EXCEPTION`) and don't touch PubNub. Same 7 fail on `development` once the test target compiles. **Not regressions.** |
| `xcodebuild test -enableCodeCoverage YES` against `ios-sdk-app` on Xcode 26.2 + iOS Simulator 26.3.1 | ✅ `** TEST SUCCEEDED **`, all 8 tests pass, `.xcresult` coverage **present** for `TSL SDK.app` (8.09%, 400/4942 lines), both xctest bundles (100% / 100%). |
| Control test — same invocation against unmodified `development` (PubNub 9.3.5) | ⚠️ **Byte-for-byte identical** coverage numbers. Bug class **not reproducible on this Xcode 26.2 + iOS 26.3.1 combo with either PubNub version.** Confirms the bump is causally inert for SPM coverage instrumentation. |

## Tag scheme

- **RC:** `9.4.0-rc1` — minor bump on the existing `9.x` line, marked pre-release. SPM's default `from: "9.3.0"` ranges exclude pre-release tags, so other workspace consumers (s2s, web-studio, web-marketplace) and `ios-sdk-app` on `development` stay on `9.3.x` automatically. Walmart can pull `9.4.0-rc1` explicitly by exact version if they wish.
- **GA:** `10.0.0` — cut after RC bake. **Not gated on Walmart's symptom resolution** — that's an unrelated workstream now (FB7724987 is consumer-config). Treats the PubNub 9 → 10 transitive bump as a breaking change for any downstream consumer that touches PubNub types directly.

**Sequence:** this PR → merge to `development` → normal release PR `development → main` → tag `9.4.0-rc1` from `main` → cut `10.0.0` GA after RC bake.

**Do not tag from this PR.** Tags ship from `main` after the standard release flow. **Do not gate the GA on Walmart's customer ticket** — they're orthogonal.

## Follow-ups (separate PRs, deferred deliberately)

- **#140 — Migrate from legacy `SubscriptionListener` to entity-scoped `Subscription` API.** PubNub 10.x ships the modern entity-scoped API alongside the legacy listener for back-compat. Our `ChatProvider.swift` still uses the legacy path. Migration deferred to keep this PR scoped.
- **DI refactor of `ChatProvider.pubnub`.** Production code holds a concrete `private var pubnub: PubNub?`, blocking isolated unit testing of the subscribe / publish / history paths. A follow-up should extract a `PubNubClientProtocol` for testability — should land before #140.

## Related

- `XCODE26_COMPATIBILITY.md` — public-facing summary in this repo for any SDK consumer hitting the same symptom (added in commit `b4ebf02`)
- Investigation history (internal): `PUBNUB_XCODE26_AUDIT.md` §9 (workspace-level, not in this repo)
- Apple Feedback FB7724987 / Swift Forums thread: https://forums.swift.org/t/xcode-doesnt-gather-code-coverage-from-packages-when-set-to-some-targets/37220
- Migration follow-up: #140
- ~~Companion PR `TalkShopLive/ios-sdk-app#42`~~ — closed; no companion change needed since this PR targets `development` and ios-sdk-app already pins `branch = development`.

## Test plan

- [ ] Merge this PR to `development`
- [ ] Run normal release PR `development → main`
- [ ] Tag `9.4.0-rc1` from `main` (with `--prerelease`) after the release merge
- [ ] Cut `10.0.0` GA after RC bake
- [ ] Customer ticket on FB7724987 is owned by whoever runs that relationship internally — **not gating this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
