### PR TITLE
chore(release): 4.1.0 — bump SDK version constant

### DIFF
--- a/Sources/Talkshoplive/Utils/Collect.swift
+++ b/Sources/Talkshoplive/Utils/Collect.swift
@@ -34,7 +34,7 @@ public class Collect {
         productId: Int? = nil,
         completion: ((Bool, APIClientError?) -> Void)? = nil
     ) {
-        let sdkVersion = "4.0.0" // Define the current SDK version.
+        let sdkVersion = "4.1.0" // Define the current SDK version.
 
         // Check if "Do Not Track" (DNT) mode is enabled.
         if Config.shared.isDntMode() == false {


### PR DESCRIPTION
## Summary
- Bump `sdkVersion` constant in `Sources/Talkshoplive/Utils/Collect.swift` from `4.0.0` → `4.1.0`
- Companion to PR #141 (PubNub `9.3.5 → 10.1.5` + Xcode 26 docs + tests, already merged)
- Sets up the `4.1.0` tag + GitHub Release for partner distribution

## Why
The PubNub 10.x bump and Xcode 26 verification work landed in #141, but the in-source SDK version constant (reported via `Collect` analytics) was not updated. This PR aligns the constant with the upcoming `4.1.0` release tag.

## Public API impact
None. One-line change to a private `let` inside `Collect.collect(...)`.

## Test plan
- [x] `swift build` clean (Xcode 26.2 / Swift 6.2.3)
- [x] No public API surface change
- [ ] After merge, tag `4.1.0` on `main` and create the GitHub Release