### PR TITLE
chore(release): bump sdkVersion 4.1.0 → 4.1.1

### DIFF
--- a/Sources/Talkshoplive/Utils/Collect.swift
+++ b/Sources/Talkshoplive/Utils/Collect.swift
@@ -34,7 +34,7 @@ public class Collect {
         productId: Int? = nil,
         completion: ((Bool, APIClientError?) -> Void)? = nil
     ) {
-        let sdkVersion = "4.1.0" // Define the current SDK version.
+        let sdkVersion = "4.1.1" // Define the current SDK version.
 
         // Check if "Do Not Track" (DNT) mode is enabled.
         if Config.shared.isDntMode() == false {


### PR DESCRIPTION
Quick follow-up to PR #146. The hotfix branch was cut from `release-4.1.0` which already had `4.1.0` as its bumped version, so the hotfix itself never bumped the patch number. Analytics were reporting `4.1.0` instead of `4.1.1` after the hotfix landed.

Single line change. Build clean.

After this merges: tag `v4.1.1` and create the GitHub Release so Bhavik/SPM can resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)