### PR TITLE
Fix/prelive show chat access

### DIFF
--- a/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
+++ b/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
@@ -61,7 +61,7 @@ public class ChatProvider {
         self.showKey = showKey
         self.setJwtToken(jwtToken)
         
-        let initClosure = { [weak self] in
+        let initClosure = {
             let sharedShow = Show.shared.showData
             
             /// In case show is in prelive state - throw error that show not started
@@ -74,11 +74,11 @@ public class ChatProvider {
             let showType = sharedShow.type
             let chatVersion = ChatVersionProvider.getVersion(showType: showType, isGuest: isGuest)
             
-            self?.chatVersion = chatVersion
+            self.chatVersion = chatVersion
             
             Config.shared.setChatVersion(chatVersion)
             
-            self?.createMessagingToken(jwtToken: jwtToken){ result, error  in
+            self.createMessagingToken(jwtToken: jwtToken){ result, error  in
                 completion?(result,error)
             }
         }
@@ -90,11 +90,18 @@ public class ChatProvider {
             Show.shared.getDetails(showKey: showKey) { result in
                 
                 /// After fetching show we check if now key is equal to the one provided, or returning error
-                if case let .success(data) = result, data.showKey == showKey {
-                    initClosure()
-                }
-                else {
-                    completion?(false, APIClientError.SHOW_NOT_FOUND)
+                
+                switch result {
+                case .success(let data):
+                    if data.showKey == showKey {
+                        initClosure()
+                    }
+                    else {
+                        completion?(false, APIClientError.SHOW_NOT_FOUND)
+                    }
+                    
+                case .failure(let error):
+                    completion?(false, error)
                 }
             }
         }

--- a/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
+++ b/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
@@ -60,11 +60,41 @@ public class ChatProvider {
         self.isGuest = isGuest
         self.showKey = showKey
         self.setJwtToken(jwtToken)
-        let showType = Show.shared.showData.type
-        self.chatVersion = ChatVersionProvider.getVersion(showType: showType, isGuest: isGuest)
-        Config.shared.setChatVersion(chatVersion!)
-        self.createMessagingToken(jwtToken: jwtToken){result,error  in
-            completion?(result,error)
+        
+        let initClosure = { [weak self] in
+            let showType = Show.shared.showData.type
+            let chatVersion = ChatVersionProvider.getVersion(showType: showType, isGuest: isGuest)
+            
+            self?.chatVersion = chatVersion
+            
+            Config.shared.setChatVersion(chatVersion)
+            
+            self?.createMessagingToken(jwtToken: jwtToken){ result,error  in
+                completion?(result,error)
+            }
+        }
+        
+        let currentSharedShow = Show.shared.showData
+        
+        /// In case ChatP initializing with different show key or show have not been fetched and stored before. We need to refetch the show to have everything consistent
+        if showKey != currentSharedShow.showKey || currentSharedShow.id == nil {
+            Show.shared.getDetails(showKey: showKey) { result in
+                
+                /// After fetching show we check if now key is equal to the one provided, or returning error
+                if case let .success(data) = result, data.showKey == showKey {
+                    
+                    /// In case show is in prelive state - throw error that show not started
+                    if data.statusEnum == .prelive {
+                        completion?(false, APIClientError.SHOW_NOT_LIVE)
+                    }
+                    else {
+                        initClosure()
+                    }
+                }
+                else {
+                    completion?(false, APIClientError.SHOW_NOT_FOUND)
+                }
+            }
         }
     }
     

--- a/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
+++ b/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
@@ -62,14 +62,23 @@ public class ChatProvider {
         self.setJwtToken(jwtToken)
         
         let initClosure = { [weak self] in
-            let showType = Show.shared.showData.type
+            let sharedShow = Show.shared.showData
+            
+            /// In case show is in prelive state - throw error that show not started
+            guard sharedShow.statusEnum != .prelive else {
+                completion?(false, APIClientError.SHOW_NOT_LIVE)
+                
+                return
+            }
+            
+            let showType = sharedShow.type
             let chatVersion = ChatVersionProvider.getVersion(showType: showType, isGuest: isGuest)
             
             self?.chatVersion = chatVersion
             
             Config.shared.setChatVersion(chatVersion)
             
-            self?.createMessagingToken(jwtToken: jwtToken){ result,error  in
+            self?.createMessagingToken(jwtToken: jwtToken){ result, error  in
                 completion?(result,error)
             }
         }
@@ -82,19 +91,15 @@ public class ChatProvider {
                 
                 /// After fetching show we check if now key is equal to the one provided, or returning error
                 if case let .success(data) = result, data.showKey == showKey {
-                    
-                    /// In case show is in prelive state - throw error that show not started
-                    if data.statusEnum == .prelive {
-                        completion?(false, APIClientError.SHOW_NOT_LIVE)
-                    }
-                    else {
-                        initClosure()
-                    }
+                    initClosure()
                 }
                 else {
                     completion?(false, APIClientError.SHOW_NOT_FOUND)
                 }
             }
+        }
+        else {
+            initClosure()
         }
     }
     

--- a/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
+++ b/Sources/Talkshoplive/Core/Chat/ChatProvider.swift
@@ -85,7 +85,7 @@ public class ChatProvider {
         
         let currentSharedShow = Show.shared.showData
         
-        /// In case ChatP initializing with different show key or show have not been fetched and stored before. We need to refetch the show to have everything consistent
+        /// In case Chat initializing with different show key or show have not been fetched and stored before. We need to refetch the show to have everything consistent
         if showKey != currentSharedShow.showKey || currentSharedShow.id == nil {
             Show.shared.getDetails(showKey: showKey) { result in
                 

--- a/Sources/Talkshoplive/Core/Show/Models/ShowData.swift
+++ b/Sources/Talkshoplive/Core/Show/Models/ShowData.swift
@@ -14,6 +14,13 @@ public enum ShowType: String, Codable {
 
 public struct ShowData: Codable {
     
+    public enum Status: String {
+        case prelive
+        case live
+        case vod
+        case transcoding
+    }
+    
     public let id: Int?
     public let showKey: String?
     public let name: String?
@@ -40,6 +47,10 @@ public struct ShowData: Codable {
     public let videoThumbnailUrl: String?
     public let type: ShowType
     
+    // TODO: remove legacy status as string and leave only enumeration
+    public var statusEnum: ShowData.Status? {
+        status.flatMap(ShowData.Status.init(rawValue:))
+    }
     
     enum CodingKeys: String, CodingKey {
         case id


### PR DESCRIPTION
## Fix chat initialization when show is not pre-fetched

### Problem

`ChatProvider` can be started with only a show key, without the host app having fetched the show first. In that scenario chat initialized against an **empty show**, made incorrect assumptions from it, and fired the wrong API requests.

The most visible symptom: an unfetched show defaults to `type = .legacy` (the empty `ShowData()` has no `v2` type), so chat picked the legacy (v1) flow and issued v1 requests for what is actually a v2 show.

**Reproduction**

1. Do **not** call `Show.getDetails` / fetch the show.
2. Initialize chat directly with a show key.
3. `ChatProvider` reads `Show.shared.showData`, finds the empty singleton, and runs the entire chat flow against that empty object.

### Root cause

Chat and Show communicate through a shared singleton (`Show.shared.showData`). `ChatProvider` assumed the singleton already held the show matching the key it was given. There was no check that:

- the singleton's show key matched the key chat was initialized with, or
- the singleton held a real show at all (vs. the default empty `ShowData()`).

When either assumption was false, `ChatProvider` operated on stale or empty state. Because an empty/unfetched show decodes as `type = .legacy`, the chat version resolver selected v1 and built v1-shaped requests for v2 shows.

This is ultimately an architectural smell — state shared implicitly via singletons rather than passed in as a dependency. Rather than rewrite the SDK's internal wiring, this change makes the singleton state consistent at the point chat starts.

### Fix

Add a guard at the start of `ChatProvider.init` that ensures the shared show is synced with the show key chat is starting with, before any chat initialization runs:

- If the provided `showKey` differs from the cached show's key, **or** the cached show is empty (`id == nil`), refetch the show with the provided key via `Show.shared.getDetails`. This updates the singleton so Show and Chat are consistent.
- After the refetch, confirm the returned show's key matches the requested key; otherwise fail with `SHOW_NOT_FOUND`.
- If the cached show already matches the requested key and is non-empty, skip the refetch and proceed directly.
- Only once the show is confirmed in sync does chat initialization run: it re-reads `Show.shared.showData`, derives the correct `showType` / chat version, and continues.

As part of the same flow, a prelive guard returns `SHOW_NOT_LIVE` when the (now correctly fetched) show is in the `prelive` state, so chat is not started before the show is live.

### Result

- Chat works correctly when initialized with only a show key, with no prior show fetch.
- v2 shows are no longer misclassified as legacy, so the correct chat version and API requests are used.
- Show and Chat singleton state is guaranteed consistent before chat starts.

### Notes / follow-ups

- This is a targeted fix that keeps the existing singleton architecture. The cleaner long-term solution is to pass the show in as an explicit dependency to `ChatProvider` rather than relying on `Show.shared`.
- The refetch is skipped when the requested key matches a non-empty cached show. Because show status is time-varying, a show fetched while `prelive` and reused later (once live) would still read the cached `prelive` status and fail with `SHOW_NOT_LIVE`. If this matters, consider also refetching when the cached status is `prelive`.
